### PR TITLE
[BDSYS-1404] Changes applied to support Debezium Ingestion from Kafka

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DebeziumAvroPayload.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.avro.generic.GenericRecord;
+
+public class DebeziumAvroPayload extends OverwriteWithLatestAvroPayload {
+
+  // Field is prefixed with a underscore by transformer to indicate metadata field
+  public static final String OP_FIELD = "_op";
+  public static final String DELETE_OP = "d";
+
+  public DebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public DebeziumAvroPayload(Option<GenericRecord> record) {
+    this(record.isPresent() ? record.get() : null, 0); // natural order
+  }
+
+  @Override
+  protected boolean isDeleteRecord(GenericRecord genericRecord) {
+    return (genericRecord.get(OP_FIELD) != null && genericRecord.get(OP_FIELD).toString().equalsIgnoreCase(
+        DELETE_OP));
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/DebeziumSchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/DebeziumSchemaRegistryProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.schema;
+
+import org.apache.hudi.AvroConversionUtils;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.SchemaBuilder.FieldAssembler;
+import org.apache.spark.api.java.JavaSparkContext;
+
+public class DebeziumSchemaRegistryProvider extends SchemaRegistryProvider {
+
+  public DebeziumSchemaRegistryProvider(TypedProperties props,
+                                        JavaSparkContext jssc) {
+    super(props, jssc);
+  }
+
+  /**
+   * Debezium target schema is a nested structure with many metadata fields. This will
+   * flatten the schema structure and only require necessary metadata information
+   * @return
+   */
+  @Override
+  public Schema getTargetSchema() {
+    Schema registrySchema = super.getTargetSchema();
+
+    Field dataField = registrySchema.getField("after");
+    Field tsField = registrySchema.getField("ts_ms");
+    Field opField = registrySchema.getField("op");
+
+    // Initialize with metadata columns
+    FieldAssembler<Schema> payloadFieldAssembler = SchemaBuilder.builder()
+        .record("formatted_debezium_payload")
+        .fields()
+        .name("_" + tsField.name()).type(tsField.schema()).withDefault(null)
+        .name("_" + opField.name()).type(opField.schema()).withDefault(null);
+
+    // Add data columns to schema
+    dataField.schema()
+        .getTypes()
+        // "after" field is a union with data schema and null schema, so we need to extract only the data schema portion
+        .get(dataField.schema().getIndexNamed(registrySchema.getNamespace() + ".Value"))
+        .getFields()
+        .forEach(field -> {
+          payloadFieldAssembler.name(field.name()).type(field.schema()).withDefault(null);
+        });
+
+    Schema schema = payloadFieldAssembler.endRecord();
+    Schema newSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+        AvroConversionUtils.convertAvroSchemaToStructType(schema), RowBasedSchemaProvider.HOODIE_RECORD_STRUCT_NAME,
+        RowBasedSchemaProvider.HOODIE_RECORD_NAMESPACE);
+    LOG.info("Transformed Avro Schema is :" + schema.toString(true));
+    LOG.info("Transformed Avro Schema after converting :" + newSchema.toString(true));
+    return newSchema;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaRegistryProvider.java
@@ -25,6 +25,8 @@ import org.apache.hudi.exception.HoodieIOException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 
 import java.io.IOException;
@@ -37,6 +39,8 @@ import java.util.Collections;
  * https://github.com/confluentinc/schema-registry
  */
 public class SchemaRegistryProvider extends SchemaProvider {
+
+  protected static final Logger LOG = LogManager.getLogger(SchemaRegistryProvider.class);
 
   /**
    * Configs supported.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/DebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/DebeziumTransformer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform;
+
+import org.apache.hudi.common.config.TypedProperties;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+public class DebeziumTransformer implements Transformer {
+
+  protected static final Logger LOG = LogManager.getLogger(DebeziumTransformer.class);
+
+  @Override
+  public Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset,
+                       TypedProperties properties) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("rowDataset schema is ");
+      rowDataset.printSchema();
+    }
+
+    Dataset<Row> insertedOrUpdatedData = rowDataset
+        .select("ts_ms", "op", "after.*")
+        .withColumnRenamed("ts_ms", "_ts_ms")
+        .withColumnRenamed("op", "_op")
+        .filter(rowDataset.col("op").notEqual("d"));
+
+    Dataset<Row> deletedData = rowDataset
+        .select("ts_ms", "op", "before.*")
+        .withColumnRenamed("ts_ms", "_ts_ms")
+        .withColumnRenamed("op", "_op")
+        .filter(rowDataset.col("op").equalTo("d"));
+
+    final Dataset<Row> transformedData = insertedOrUpdatedData.union(deletedData);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("TransformedData schema is ");
+      transformedData.printSchema();
+    }
+    return transformedData;
+  }
+}


### PR DESCRIPTION
## Description 

These are the changes applied to the master upstream branch of hudi in order to support Debezium Connector with Spark 3. 

I used the below command to compile this:
```bash
mvn clean package -DskipTests -Dscala-2.12 -Dspark3
```

After compilation you will find the jars and classes needed under the below paths.
```
hudi-common/target/classes/org/apache/hudi/common/model/DebeziumAvroPayload.class
hudi/packaging/hudi-spark-bundle/target/hudi-spark-bundle_2.12-0.7.0-SNAPSHOT.jar
hudi/packaging/hudi-utilities-bundle/target/hudi-utilities-bundle_2.12-0.7.0-SNAPSHOT.jar
hudi/packaging/hudi-hadoop-mr-bundle/target/hudi-hadoop-mr-bundle-0.7.0-SNAPSHOT.jar
```

Base Docker Image used for spark : `harbor.mgmt.bigdata.thebeat.co/beat-bigdata/spark:v3.0.1-hadoop3.2`
In order to work properly with S3 I used the below jars in the spark Docker image
```
aws-java-sdk-bundle-1.11.563.jar
DebeziumAvroPayload.class
hadoop-aws-3.2.0.jar
hudi-spark-bundle_2.12-0.7.0-SNAPSHOT.jar
hudi-utilities-bundle_2.12-0.7.0-SNAPSHOT.jar
jets3t-0.9.4.jar
mysql-connector-java-5.1.48.jar
spark-avro_2.12-2.4.4.jar
```

Used the below command to deploy it: 
```bash
#!/bin/bash
/opt/spark/bin/spark-submit \
  --master k8s://api.dev.bigdata.thebeat.co:443 \
  --name deltaStreamer-test \
  --deploy-mode cluster \
  --conf spark.driver.extraJavaOptions="-Divy.cache.dir=/tmp -Divy.home=/tmp" \
  --conf spark.executor.extraJavaOptions="-Divy.cache.dir=/tmp -Divy.home=/tmp" \
  --conf spark.kubernetes.namespace=cdc \
  --conf spark.executor.instances=2 \
  --conf spark.kubernetes.driver.request.cores=500m \
  --conf spark.kubernetes.driver.request.memory=1G \
  --conf spark.kubernetes.driver.limit.cores=1 \
  --conf spark.kubernetes.driver.limit.memory=1G \
  --conf spark.kubernetes.executor.request.cores=250m \
  --conf spark.kubernetes.executor.request.memory=2G \
  --conf spark.kubernetes.executor.limit.cores=1 \
  --conf spark.kubernetes.executor.limit.memory=2G \
  --conf spark.kubernetes.container.image=harbor.mgmt.bigdata.thebeat.co/beat-bigdata/spark:v3.0.1-3.2-cdc-withDeps-v9 \
  --conf spark.kubernetes.executor.podTemplateFile=$(pwd)/podTemplates/executorPodTemplate.yaml \
  --conf spark.kubernetes.driver.podTemplateFile=$(pwd)/podTemplates/driverPodTemplate.yaml \
  --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
  --conf spark.kubernetes.executor.annotation.iam\.amazonaws\.com\/role=CDC-TestRole \
  --conf spark.task.maxFailures=2 \
  --conf spark.rdd.compress=true \
  --conf spark.sql.hive.convertMetastoreParquet=false \
  --conf spark.driver.maxResultSize=3g \
  --conf spark.executor.heartbeatInterval=120s \
  --conf spark.network.timeout=600s \
  --conf spark.eventLog.enabled=false \
  --conf spark.sql.catalogImplementation=hive \
  --conf spark.sql.shuffle.partitions=100 \
  --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
  --class org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer \
  local:///opt/spark/jars/hudi-utilities-bundle_2.12-0.7.0-SNAPSHOT.jar \
  --table-type COPY_ON_WRITE \
  --source-class org.apache.hudi.utilities.sources.AvroKafkaSource \
  --source-ordering-field _ts_ms  \
  --target-base-path s3a://beat-bigdata-hive-co-dev/external/migration_attempt \
  --target-table cdc.migration_attempt \
  --props /opt/spark/extra-configs/kafka-source.properties \
  --continuous \
  --schemaprovider-class org.apache.hudi.utilities.schema.DebeziumSchemaRegistryProvider \
  --transformer-class org.apache.hudi.utilities.transform.DebeziumTransformer \
  --payload-class org.apache.hudi.common.model.DebeziumAvroPayload \
  --enable-sync
```
